### PR TITLE
Add support for "reconnect" status

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -243,7 +243,7 @@ module.exports = function (RED) {
     // Listener functions that can be removed on reconnect
     const reestablish = function () {
       // verbose_warn(" !!!!!!!!!!!!!!!!!!!!!!!!  CONNECTION RE-ESTABLISHED !!!!!!!!!!!!!!!!!!! Node: " + node.name);
-      set_node_status2_to("reconnect", "re-establised");
+      set_node_status2_to("reconnect", "re-established");
     };
     const backoff = function (attempt, delay) {
       // verbose_warn("backoff  attempt #" + attempt + " retrying in " + delay / 1000.0 + " seconds. Node:  " + node.name + " " + opcuaEndpoint.endpoint);

--- a/opcua/107-opcuamethod.js
+++ b/opcua/107-opcuamethod.js
@@ -56,6 +56,17 @@ module.exports = function (RED) {
       });
     }
 
+    function set_node_status2_to(statusValue, message) {
+      verbose_log("Client status: " + statusValue);
+      var statusParameter = opcuaBasics.get_node_status(statusValue);
+      currentStatus = statusValue;
+      node.status({
+        fill: statusParameter.fill,
+        shape: statusParameter.shape,
+        text: statusParameter.status + " " + message
+      });
+    }
+
     if (n.arg0type === undefined || n.arg0type === "" || n.arg0value === "") {
       // Do nothing
     } else if (n.arg0type === "Boolean") {
@@ -183,9 +194,14 @@ module.exports = function (RED) {
     }
     node.debug("Input arguments:" + JSON.stringify(node.inputArguments));
     
+    set_node_status_to("initialized")
+
     async function setupClient(url, message, callback) {
 
       const client = opcua.OPCUAClient.create(connectionOption);
+      client.on("connection_reestablished", reestablish);
+      client.on("backoff", backoff);
+      client.on("start_reconnection", reconnection);
       try {
         // step 1 : connect to
         await client.connect(url);
@@ -221,6 +237,23 @@ module.exports = function (RED) {
         callback(err);
       }
     }
+
+    const reestablish = function () {
+      set_node_status2_to("reconnect", "re-establised");
+    };
+    
+    const backoff = function (attempt, delay) {
+      var msg = {};
+      msg.error = {};
+      msg.error.message = "reconnect";
+      msg.error.source = this;
+      node.error("reconnect", msg);
+      set_node_status2_to("reconnect", "attempt #" + attempt + " retry in " + delay / 1000.0 + " sec");
+    };
+
+    const reconnection = function () {
+      set_node_status2_to("reconnect", "starting...");
+    };
 
     function node_error(err) {
       // console.error(chalk.red("Client node error on node: " + node.name + "; error: " + stringify(err)));

--- a/opcua/107-opcuamethod.js
+++ b/opcua/107-opcuamethod.js
@@ -45,25 +45,14 @@ module.exports = function (RED) {
     var currentStatus = '';
     node.outputArguments = [];
 
-    function set_node_status_to(statusValue) {
+    function set_node_status_to(statusValue, message = "") {
       verbose_log("Client status: " + statusValue);
       var statusParameter = opcuaBasics.get_node_status(statusValue);
       currentStatus = statusValue;
       node.status({
         fill: statusParameter.fill,
         shape: statusParameter.shape,
-        text: statusParameter.status
-      });
-    }
-
-    function set_node_status2_to(statusValue, message) {
-      verbose_log("Client status: " + statusValue);
-      var statusParameter = opcuaBasics.get_node_status(statusValue);
-      currentStatus = statusValue;
-      node.status({
-        fill: statusParameter.fill,
-        shape: statusParameter.shape,
-        text: statusParameter.status + " " + message
+        text: (statusParameter.status + " " + message).trim()
       });
     }
 
@@ -239,7 +228,7 @@ module.exports = function (RED) {
     }
 
     const reestablish = function () {
-      set_node_status2_to("reconnect", "re-established");
+      set_node_status_to("reconnect", "re-established");
     };
     
     const backoff = function (attempt, delay) {
@@ -248,11 +237,11 @@ module.exports = function (RED) {
       msg.error.message = "reconnect";
       msg.error.source = this;
       node.error("reconnect", msg);
-      set_node_status2_to("reconnect", "attempt #" + attempt + " retry in " + delay / 1000.0 + " sec");
+      set_node_status_to("reconnect", "attempt #" + attempt + " retry in " + delay / 1000.0 + " sec");
     };
 
     const reconnection = function () {
-      set_node_status2_to("reconnect", "starting...");
+      set_node_status_to("reconnect", "starting...");
     };
 
     function node_error(err) {

--- a/opcua/107-opcuamethod.js
+++ b/opcua/107-opcuamethod.js
@@ -239,7 +239,7 @@ module.exports = function (RED) {
     }
 
     const reestablish = function () {
-      set_node_status2_to("reconnect", "re-establised");
+      set_node_status2_to("reconnect", "re-established");
     };
     
     const backoff = function (attempt, delay) {


### PR DESCRIPTION
With this PR, the node will show a reconnect status similar to that of the OPC-UA Client whenever the `client.connect()` fails, instead of having an "Executing Method" status for as long as 10 years.