### PR TITLE
Add "isReconnecting" check to close function

### DIFF
--- a/opcua/102-opcuaclient.js
+++ b/opcua/102-opcuaclient.js
@@ -303,17 +303,19 @@ module.exports = function (RED) {
     function close_opcua_client(message, error) {
       if (node.client) {
         try {
-          node.client.disconnect(function () {
-            node.client = null;
-            verbose_log("Client disconnected!");
-            if (error === 0) {
-              set_node_status_to("closed");
-            }
-            else {
-              set_node_errorstatus_to(message, error)
-              node.error("Client disconnected & closed: " + message + " error: " + error.toString());
-            }
-          });
+          if(!node.client.isReconnecting){
+            node.client.disconnect(function () {
+              node.client = null;
+              verbose_log("Client disconnected!");
+              if (error === 0) {
+                set_node_status_to("closed");
+              }
+              else {
+                set_node_errorstatus_to(message, error)
+                node.error("Client disconnected & closed: " + message + " error: " + error.toString());
+              }
+            });
+          }
         }
         catch (err) {
           node_error("Error on disconnect: " + stringify(err));


### PR DESCRIPTION
Fix an issue that happened when 2 or more `opcua-client` nodes where not yet connected and the flows were redeployed.

In order to review this, add 2 or more  `opcua-client` nodes to a flow with IPs that don't point to an actual OPC-UA server, and redeploy the flows. Before this PR, Node-RED should throw and uncatchable error, and after the PR everything should be smoothly redeployed.